### PR TITLE
🔩  Added `bankAccountName` to BankInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/onbo-node-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Node.js Client for Onbo API",
   "keywords": [
     "withpersona.com",

--- a/src/loc/index.ts
+++ b/src/loc/index.ts
@@ -43,6 +43,7 @@ export interface Offer {
 export interface BankInfo {
   achRoutingNumber: string;
   bankAccountNumber: string;
+  bankAccountName?: string;
   bankName: string;
   accountType: string;
 }


### PR DESCRIPTION
As it turns out, the `bankAccountName` is required for the BankInfo
object, so we needed to add it in order to support it. Just keeping up
with the tests and integration work.