### PR TITLE
🔧  We needed to change `list` to `get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ All Line of Credit Statement calls are grouped under `loc.statement`.
 You can get the statement for the LOC with a single call:
 
 ```typescript
-const resp = await client.loc.statement.list(userId, locId)
+const resp = await client.loc.statement.get(userId, locId)
 ```
 
 and the response will be something like:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/onbo-node-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Node.js Client for Onbo API",
   "keywords": [
     "withpersona.com",

--- a/src/loc/statement.ts
+++ b/src/loc/statement.ts
@@ -13,10 +13,10 @@ export class StatementApi {
   }
 
   /*
-   * Function to take a userId and locId and return a list of all the
-   * Repayments made against that LOC in Onbo.
+   * Function to take a userId and locId and return a complete Statement
+   * for that LOC in Onbo.
    */
-  async list(userId: string, locId: string): Promise<{
+  async get(userId: string, locId: string): Promise<{
     success: boolean,
     statement?: Statement,
     error?: OnboError,


### PR DESCRIPTION
The idea that a Statement is obtained by a `list()` when there is only
one is bad... it's better ot make it a `get()`.